### PR TITLE
1일차(22.07.09) BJ1008, 1152, 1157

### DIFF
--- a/res-cogitans/javaTest/bj1157.java
+++ b/res-cogitans/javaTest/bj1157.java
@@ -9,12 +9,11 @@ import java.util.Set;
 import java.util.Map.Entry;
 
 // public class Main{
-public class Backjoon {
+public class bj1157 {
     
     public static void main(String[] args) throws IOException {
-        // BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        // String input = br.readLine();
-        String input = "Mississipi"; 
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
         char[] charArray = input.toCharArray();
 
         Map<Character, Integer> countMap = new HashMap<>();


### PR DESCRIPTION
## BJ 1008
- 단순히 나눗셈 결과를 출력하는 문제였습니다.
- `require('fs')`이 `import`의 다른 형태임을 알았습니다. 자바스크립트 모듈 방식에 따라 다르다고 하는데, 추가적인 공부가 진행되면서 명확해질 듯 합니다.

## BJ 1152
- 단순히 문자열 배열로 구별하여 받고, 배열 길이를 측정하는 방식으로 풀 수 있다고 생각했습니다만,
- 빈 문자열이 들어올 경우의 처리를 하지 않아서 문제가 발생했습니다. 문제 풀이 시 `공백 처리`에 대해 한 번 더 생각해봐야겠습니다.

## BJ 1157
- 해법 자체는 빠르게 찾았지만, `대/소문자 구별`을 잊어서,
- 백준에서 해답 출력은 `콘솔 창 출력으로 해야 한다`는 것을 망각하여 문제를 틀렸었습니다.
- 문제를 너무 복잡하게 푸는 경향이 있는 것 같아서, 다른 사람 코드를 좀 더 봐야겠습니다.