### PR TITLE
2일차: 07월 10일 백준 BJ1546, BJ8958

### DIFF
--- a/res-cogitans/javaTest/bj1546.java
+++ b/res-cogitans/javaTest/bj1546.java
@@ -1,0 +1,48 @@
+package javaTest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class bj1546 {
+    
+    public static void main(String[] args) throws IOException {
+        // BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        // int subjectCount = Integer.parseInt(br.readLine());
+        // StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // int[] scores = new int[subjectCount];
+
+        int subjectCount = 3;
+        int[] scores = {40, 80, 60};
+
+        // for (int i = 0; i < subjectCount; i++) {
+        //     scores[i] = Integer.parseInt(st.nextToken());
+        // }
+
+        int theGreatest = getGreatestOf(scores);
+        double sum = 0;
+
+        for (int score: scores) {
+            sum += getNewScoreOf(score, theGreatest);
+        }
+
+        System.out.println(sum/subjectCount);
+    }
+
+    private static int getGreatestOf(int[] numbers) {
+        int max = 0;
+        for (int number : numbers) {
+            if (number >= max) {
+                max = number;
+            }
+        }
+        System.out.println(max);
+        return max;
+    }
+
+    private static double getNewScoreOf(int score, int greatest) {
+        return score * 100 / greatest;
+    }
+}


### PR DESCRIPTION
## BJ1546
- String Tokenizer 사용할 때 구분자를 꼭 넣어줍시다.

## BJ8958
- 입력을 받아올 때 `answer[i]`에 받아올 것을 모조리 `answer[0]`에 받아오는 실수를 했습니다.
- 입력 / 출력을 정신 차려 구현합시다.