### PR TITLE
[epicblues] 2022.08.28

### DIFF
--- a/epicblues/baekjoon/Problem_1406.java
+++ b/epicblues/baekjoon/Problem_1406.java
@@ -1,0 +1,139 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Problem_1406 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		var input = br.readLine();
+		var buffer = new CursorLinkedList<Character>();
+		for (int i = 0; i < input.length(); i++) {
+			buffer.append(input.charAt(i));
+		}
+		int n = Integer.parseInt(br.readLine());
+		for (int i = 0; i < n; i++) {
+			var commands = br.readLine();
+			var front = commands.charAt(0);
+			if (front == 'L') {
+				buffer.left();
+				continue;
+			}
+			if (front == 'D') {
+				buffer.right();
+				continue;
+			}
+
+			if (front == 'B') {
+				buffer.delete();
+				continue;
+			}
+
+			if (front == 'P') {
+				buffer.insertPrevCursor(commands.split(" ")[1].charAt(0));
+			}
+
+		}
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		while (buffer.head != null) {
+			bw.append(buffer.head.data);
+			buffer.head = buffer.head.next;
+		}
+
+		bw.flush();
+	}
+
+	static class CursorLinkedList<T> {
+		Node<T> cursor = new Node<>(null);
+		Node<T> head;
+
+		void append(T data) {
+			if (head == null) {
+				head = new Node<>(data);
+				cursor.prev = head;
+				return;
+			}
+
+			var newNode = new Node<T>(data);
+			cursor.prev.next = newNode;
+			newNode.prev = cursor.prev;
+			cursor.prev = newNode;
+			cursor.next = null;
+		}
+
+		void delete() {
+
+			if (cursor.prev == null) {
+				return;
+			}
+
+			var target = cursor.prev;
+
+			if (target.prev != null) {
+				target.prev.next = target.next;
+			}
+
+			if (target.next != null) {
+				target.next.prev = target.prev;
+			}
+			cursor.prev = target.prev;
+			cursor.next = target.next;
+			if (target == head) {
+				head = cursor.next;
+			}
+
+		}
+
+		void insertPrevCursor(T data) {
+			var target = new Node<>(data);
+
+			if (cursor.prev != null) {
+				cursor.prev.next = target;
+			} else {
+				// 왼쪽 끝자락에 있었다는 것.
+				head = target;
+			}
+			target.prev = cursor.prev;
+			cursor.prev = target;
+			if (cursor.next != null) {
+				cursor.next.prev = target;
+			}
+			target.next = cursor.next;
+		}
+
+		void left() {
+			var prev = cursor.prev;
+			if (prev == null) {
+				return;
+			}
+			cursor.prev = prev.prev;
+			cursor.next = prev;
+		}
+
+		void right() {
+			var next = cursor.next;
+			if (next == null) {
+				return;
+			}
+
+			cursor.next = next.next;
+			cursor.prev = next;
+		}
+
+		private static class Node<T> {
+			T data;
+			Node<T> next;
+			Node<T> prev;
+
+			Node(T data) {
+				this.data = data;
+				this.next = null;
+				this.prev = null;
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
[백준 1406](https://www.acmicpc.net/problem/1406)

연결 리스트


단순하게 연결리스트의 수정 / 삭제 연산이 무조건 상수 시간이라 생각해서 시간 초과 문제로 고생했습니다.

특정 인덱스에 위치한 노드의 수정/ 삭제 연산은 아무리 연결 리스트라도 해당 인덱스까지 접근하는 시간 때문에 O(N)의 시간이 걸린다는 것을 인지해야 겠습니다.

다른 사람들의 풀이에서 listIterator를 쓰는 것을 착안하여, 내부의 문제의 커서가 존재하는 연결 리스트를 만들어서 해결했습니다.

head가 바뀌는 경우의 수를 고려해야 하고, 커서가 좌/우로 이동할 때 커서가 가리키는 영역을 제대로 확인하지 못해서 시간이 걸렸습니다.