### PR TITLE
[epicblues] 2022.09.05

### DIFF
--- a/epicblues/programmers/Problem_81303.java
+++ b/epicblues/programmers/Problem_81303.java
@@ -1,0 +1,106 @@
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class Problem_81303 {
+
+  public String solution(int n, int k, String[] cmd) {
+
+    Node head = new Node(0);
+
+    Node front = head;
+    Node cursor = null;
+
+    if (k == 0) {
+      cursor = head;
+    }
+    for (int i = 1; i < n; i++) {
+      Node node = new Node(i);
+      front.next = node;
+      node.prev = front;
+      if (i == k) {
+        cursor = node;
+      }
+      front = node;
+    }
+
+    Deque<Node> deletedStack = new LinkedList<>();
+
+    for (String command : cmd) {
+      var key = command.charAt(0);
+
+      if (key == 'U') {
+        int offset = Integer.parseInt(command.split(" ")[1]);
+        for (int i = 0; i < offset; i++) {
+          if (cursor.prev == null) {
+            break;
+          }
+          cursor = cursor.prev;
+        }
+        continue;
+      }
+
+      if (key == 'D') {
+        int offset = Integer.parseInt(command.split(" ")[1]);
+        for (int i = 0; i < offset; i++) {
+          if (cursor.next == null) {
+            break;
+          }
+          cursor = cursor.next;
+        }
+        continue;
+      }
+
+      if (key == 'C') {
+        deletedStack.push(cursor);
+        if (cursor.prev != null) {
+          cursor.prev.next = cursor.next;
+        }
+
+        if (cursor.next != null) {
+          cursor.next.prev = cursor.prev;
+          cursor = cursor.next;
+        } else {
+          cursor = cursor.prev;
+        }
+        continue;
+      }
+
+      if (key == 'Z') {
+
+        var restoredNode = deletedStack.pop();
+        if (restoredNode.prev != null) {
+          restoredNode.prev.next = restoredNode;
+        }
+        if (restoredNode.next != null) {
+          restoredNode.next.prev = restoredNode;
+        }
+      }
+    }
+
+    var answerTable = new boolean[n];
+
+    while (!deletedStack.isEmpty()) {
+      answerTable[deletedStack.pop().data] = true;
+    }
+
+    var answerBuilder = new StringBuilder(n);
+
+    for (int i = 0; i < n; i++) {
+      answerBuilder.append(answerTable[i] ? 'X' : 'O');
+    }
+
+    return answerBuilder.toString();
+  }
+
+  static class Node {
+
+    int data;
+    Node prev;
+    Node next;
+
+    Node(int data) {
+      this.data = data;
+    }
+  }
+
+}


### PR DESCRIPTION
[프로그래머스 81303](https://school.programmers.co.kr/learn/courses/30/lessons/81303) 표 편집

연결 리스트
스택

커서 1회 이동의 탐색 비용을 O(1)으로 줄이기 위해 연결 리스트를 사용했습니다.
삭제된 노드를 스택에 담았습니다. 삭제된 노드는 삭제되기 직전의 연결되었던 노드 주소를 담고 있습니다.
주소들을 활용해서 복구를 수행할 때 O(1) 만에 위치를 찾을 수 있습니다.