### PR TITLE
[epicblues] 2022.09.10

### DIFF
--- a/epicblues/programmers/Problem_72412.java
+++ b/epicblues/programmers/Problem_72412.java
@@ -1,100 +1,72 @@
-import java.util.*;
+import static java.util.Collections.binarySearch;
 
-class Problem_72412 {
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Problem_72412 {
+
   public int[] solution(String[] info, String[] queries) {
 
     var cache = new HashMap<String, Integer>();
 
     var answer = new int[queries.length];
 
-    var table = new TreeMap<Integer, List<Integer>>();
+    var queryCache = new HashMap<String, List<Float>>();
 
-    for (String rec : info) {
-      var recArr = rec.split(" ");
-      var recBuilder = new StringBuilder();
-      if (recArr[0].charAt(0) == 'c') {
-        recBuilder.append("001");
-      } else if (recArr[0].charAt(0) == 'j') {
-        recBuilder.append("010");
-      } else {
-        recBuilder.append("100");
+    var lang = List.of("000", "001", "010", "100");
+    var otherTypes = List.of("00", "01", "10");
+    for (String a : lang) {
+      for (String b : otherTypes) {
+        for (String c : otherTypes) {
+          for (String d : otherTypes) {
+            queryCache.put(a + b + c + d, new ArrayList<>());
+          }
+        }
       }
-      if (recArr[1].charAt(0) == 'f') {
-        recBuilder.append("01");
-      } else {
-        recBuilder.append("10");
-      }
-      if (recArr[2].charAt(0) == 'j') {
-        recBuilder.append("01");
-      } else {
-        recBuilder.append("10");
-      }
-      if (recArr[3].charAt(0) == 'c') {
-        recBuilder.append("01");
-      } else {
-        recBuilder.append("10");
-      }
+    }
 
-      var score = Integer.parseInt(recArr[4]);
+    var langTable = Map.of("-", "000", "java", "100", "python", "010", "cpp", "001");
+    var jobTable = Map.of("-", "00", "frontend", "01", "backend", "10");
+    var careerTable = Map.of("-", "00", "junior", "01", "senior", "10");
+    var foodTable = Map.of("-", "00", "chicken", "01", "pizza", "10");
 
-      if (!table.containsKey(score)) {
-        table.put(score, new LinkedList<>());
+    for (String row : info) {
+      var recs = row.split(" ");
+      for (String a : List.of("000", langTable.get(recs[0]))) {
+        for (String b : List.of("00", jobTable.get(recs[1]))) {
+          for (String c : List.of("00", careerTable.get(recs[2]))) {
+            for (String d : List.of("00", foodTable.get(recs[3]))) {
+              float num = Float.parseFloat(recs[4]);
+              queryCache.get(a + b + c + d).add(num);
+            }
+          }
+        }
       }
-      table.get(score).add(Integer.parseInt(recBuilder.toString(), 2));
+    }
+
+    // 정렬
+    for (List<Float> list : queryCache.values()) {
+      list.sort(Comparator.naturalOrder());
     }
 
     for (int i = 0; i < queries.length; i++) {
       var queryBuilder = new StringBuilder();
       var query = queries[i].split(" and ");
-      var lang = query[0].charAt(0);
-      if (lang == '-') {
-        queryBuilder.append("000");
-      } else if (lang == 'c') {
-        queryBuilder.append("001");
-      } else if (lang == 'j') {
-        queryBuilder.append("010");
-      } else {
-        queryBuilder.append("100");
-      }
-      var end = query[1].charAt(0);
-      if (end == '-') {
-        queryBuilder.append("00");
-      } else if (end == 'f') {
-        queryBuilder.append("01");
-      } else {
-        queryBuilder.append("10");
-      }
-      var career = query[2].charAt(0);
-      if (career == '-') {
-        queryBuilder.append("00");
-      } else if (career == 'j') {
-        queryBuilder.append("01");
-      } else {
-        queryBuilder.append("10");
-      }
-      var food = query[3].charAt(0);
-      if (food == '-') {
-        queryBuilder.append("00");
-      } else if (food == 'c') {
-        queryBuilder.append("01");
-      } else {
-        queryBuilder.append("10");
-      }
-      var score = Integer.parseInt(query[3].split(" ")[1]);
-      var numQuery = Integer.parseInt(queryBuilder.toString(), 2);
-      var cacheKey = "" + numQuery + " " + score;
-      if (cache.containsKey(cacheKey)) {
-        answer[i] = cache.get(cacheKey);
-        continue;
-      }
+      queryBuilder.append(langTable.get(query[0]));
+      queryBuilder.append(jobTable.get(query[1]));
+      queryBuilder.append(careerTable.get(query[2]));
+      queryBuilder.append(foodTable.get(query[3].split(" ")[0]));
 
-      for (List<Integer> list : table.tailMap(score, true).values()) {
-        for (int num : list) {
-          answer[i] = (num & numQuery) == numQuery ? answer[i] + 1 : answer[i];
-        }
-        cache.put(cacheKey, answer[i]);
-      }
-
+      int num = Integer.parseInt(query[3].split(" ")[1]);
+      // 이분 탐색으로 최소 인덱스 찾는다.
+      var targetList = queryCache.get(queryBuilder.toString());
+      // 중복되는 상황을 고려하여 0.1 낮은 숫자를 탐색시킨다.
+      // binarySearch에서 탐색이 실패했을 경우, 그 숫자보다 큰 숫자의 첫 번째 숫자의 index + 1을 음수로 반환한다.
+      int index = binarySearch(targetList, num - 0.1f);
+      answer[i] = targetList.size() + index - 1;
     }
 
     return answer;


### PR DESCRIPTION
[프로그래머스 72412](https://school.programmers.co.kr/learn/courses/30/lessons/72412)

효율성 테스트까지 통과시켰습니다.

레코드를 순회할 때, 해당 레코드를 탐색할 수 있는 모든 쿼리 형식에 레코드를 cache 시켰습니다.

쿼리를 순회하면서 해당 쿼리에 캐시된 점수 데이터를 이분 탐색을 통해 개수를 구할 수 있었습니다.

자바 라이브러리의 이분 탐색은 실패했을 경우, 해당 대상보다 다음 우선 순위를 가진 값의 index를 `-(index + 1)`으로 반환한다는 것을 읽지 않아서 시간을 날렸습니다.