### PR TITLE
[epicblues] 2022.09.14

### DIFF
--- a/epicblues/baekjoon/Problem_11931.java
+++ b/epicblues/baekjoon/Problem_11931.java
@@ -1,0 +1,70 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Problem_11931 {
+
+  static int[] nums;
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    int n = Integer.parseInt(br.readLine());
+    nums = new int[n];
+    for (int i = 0; i < n; i++) {
+      nums[i] = Integer.parseInt(br.readLine());
+    }
+
+    // 퀵 정렬
+    quickSortByIndex(0, nums.length - 1);
+
+    var answer = new StringBuilder();
+    for (int i = 0; i < n; i++) {
+      answer.append(nums[i]).append("\n");
+    }
+    answer.deleteCharAt(answer.length() - 1);
+    System.out.println(answer);
+  }
+
+  private static void quickSortByIndex(int start, int end) {
+    if (start >= end) {
+      return;
+    }
+    int pivot = (start + end) / 2;
+    int pivotValue = nums[pivot];
+    // 피벗 숫자를 앞으로 뺀다.
+    int temp = nums[pivot];
+    nums[pivot] = nums[start];
+    nums[start] = temp;
+
+    int leftIndex = start + 1;
+    int rightIndex = end;
+    while (leftIndex <= rightIndex) {
+      int greaterNum = nums[leftIndex];
+      int smallerNum = nums[rightIndex];
+
+      if (greaterNum >= pivotValue) {
+        leftIndex++;
+        continue;
+      }
+
+      if (smallerNum < pivotValue) {
+        rightIndex--;
+        continue;
+      }
+
+      temp = nums[leftIndex];
+      nums[leftIndex] = nums[rightIndex];
+      nums[rightIndex] = temp;
+
+    }
+
+    temp = nums[rightIndex];
+    nums[rightIndex] = nums[start];
+    nums[start] = temp;
+
+    quickSortByIndex(start, rightIndex - 1);
+    quickSortByIndex(rightIndex + 1, end);
+
+  }
+
+}


### PR DESCRIPTION
[백준 11931](https://www.acmicpc.net/problem/11931)

정렬

연습 삼아 퀵 정렬을 직접 구현해서 풀었습니다.
처음에는 피벗을 가장 왼쪽에 있는 것으로 잡았기 때문에, 숫자가 오름차순으로 되어있을 경우 시간복잡도가 O(n2)이 되어서 시간 초과가 되었습니다.
피벗을 중앙에 있는 원소로 잡고 다시 구현해서 해결했습니다.
먼저 피벗 숫자를 이동(인덱스의 처음이나 끝)시킨 뒤에 피벗 값 기준으로 정렬시키는 것을 생각하지 못해서 시간을 날렸습니다.